### PR TITLE
Use metadata from counters as tags in AppMetrics

### DIFF
--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector.sln
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Neyro.AppMetrics.Extensions
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleApp", "sandbox\ExampleApp\ExampleApp.csproj", "{3BEA4C04-E3E2-4C89-9C4C-14584EF58D48}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{D6A64B61-1F06-4369-8374-828997337E2A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{3BEA4C04-E3E2-4C89-9C4C-14584EF58D48}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BEA4C04-E3E2-4C89-9C4C-14584EF58D48}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BEA4C04-E3E2-4C89-9C4C-14584EF58D48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6A64B61-1F06-4369-8374-828997337E2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6A64B61-1F06-4369-8374-828997337E2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6A64B61-1F06-4369-8374-828997337E2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6A64B61-1F06-4369-8374-828997337E2A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/CounterPayload.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/CounterPayload.cs
@@ -1,6 +1,4 @@
-﻿using App.Metrics;
-using App.Metrics.Gauge;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Neyro.AppMetrics.Extensions
 {
@@ -9,6 +7,7 @@ namespace Neyro.AppMetrics.Extensions
         public string Name { get; }
         public double Value { get; }
         public CounterType Type { get; }
+        public IDictionary<string,string> Metadata { get; }
 
         public CounterPayload(IDictionary<string, object> payloadFields)
         {
@@ -40,6 +39,30 @@ namespace Neyro.AppMetrics.Extensions
                     Type = CounterType.Mean;
                 }
             }
+
+            Metadata = ExtractTagsFromMetadata(payloadFields);
+        }
+        
+
+        private static Dictionary<string, string> ExtractTagsFromMetadata(IDictionary<string, object> payloadFields)
+        {
+            var metadata = new Dictionary<string,string>();
+
+            if (payloadFields.ContainsKey("Metadata"))
+            {
+                string? payloadMetadata = payloadFields["Metadata"] as string;
+                var metaKVs = payloadMetadata?.Split(",");
+                if (metaKVs != null)
+                    foreach(var strKv in metaKVs)
+                    {
+                        var kv = strKv.Split(":");
+                        if (kv.Length != 2)
+                            continue;
+                        metadata.Add(kv[0], kv[1]);
+                    }
+            }
+
+            return metadata;
         }
     }
 }

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollector.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollector.cs
@@ -103,9 +103,14 @@ namespace Neyro.AppMetrics.Extensions
             {
                 counter = new CounterOptions
                 {
-                    Context = eventSourceName, Name = payload.Name, ResetOnReporting = true,
-                    Tags = new MetricTags(payload.Metadata.Keys.ToArray(), payload.Metadata.Values.ToArray())
+                    Context = eventSourceName, Name = payload.Name, ResetOnReporting = true
                 };
+
+                if (_options.SetTagsFromMetadata)
+                {
+                    counter.Tags = new MetricTags(payload.Metadata.Keys.ToArray(), payload.Metadata.Values.ToArray());
+                }
+                
                 _counters.Add(countersCacheKey, counter);
             }
             _metrics.Measure.Counter.Increment(counter, (long)payload.Value);
@@ -119,9 +124,14 @@ namespace Neyro.AppMetrics.Extensions
                 gauge = new GaugeOptions
                 {
                     Context = eventSourceName,
-                    Name = payload.Name,
-                    Tags = new MetricTags(payload.Metadata.Keys.ToArray(), payload.Metadata.Values.ToArray())
+                    Name = payload.Name
                 };
+
+                if (_options.SetTagsFromMetadata)
+                {
+                    gauge.Tags = new MetricTags(payload.Metadata.Keys.ToArray(), payload.Metadata.Values.ToArray());
+                }
+
                 _gauges.Add(gaugesCacheKey, gauge);
             }
             _metrics.Measure.Gauge.SetValue(gauge, payload.Value);

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollector.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollector.cs
@@ -101,7 +101,11 @@ namespace Neyro.AppMetrics.Extensions
             var countersCacheKey = eventSourceName + payload.Name;
             if (!_counters.TryGetValue(countersCacheKey, out var counter))
             {
-                counter = new CounterOptions { Context = eventSourceName, Name = payload.Name, ResetOnReporting = true };
+                counter = new CounterOptions
+                {
+                    Context = eventSourceName, Name = payload.Name, ResetOnReporting = true,
+                    Tags = new MetricTags(payload.Metadata.Keys.ToArray(), payload.Metadata.Values.ToArray())
+                };
                 _counters.Add(countersCacheKey, counter);
             }
             _metrics.Measure.Counter.Increment(counter, (long)payload.Value);
@@ -112,7 +116,12 @@ namespace Neyro.AppMetrics.Extensions
             var gaugesCacheKey = eventSourceName + payload.Name;
             if (!_gauges.TryGetValue(gaugesCacheKey, out var gauge))
             {
-                gauge = new GaugeOptions { Context = eventSourceName, Name = payload.Name };
+                gauge = new GaugeOptions
+                {
+                    Context = eventSourceName,
+                    Name = payload.Name,
+                    Tags = new MetricTags(payload.Metadata.Keys.ToArray(), payload.Metadata.Values.ToArray())
+                };
                 _gauges.Add(gaugesCacheKey, gauge);
             }
             _metrics.Measure.Gauge.SetValue(gauge, payload.Value);

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollectorOptions.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollectorOptions.cs
@@ -11,6 +11,12 @@
         public int RefreshIntervalSec {  get; set; } = 5; 
 
         /// <summary>
+        /// Whether metadata should be parsed from the event counters api and populated as AppMetrics tags
+        /// Defaults to false so tags don't break existing metrics
+        /// </summary>
+        public bool  SetTagsFromMetadata { get; set; } = false;
+        
+        /// <summary>
         /// Enabled EventCounter's sources
         /// </summary>
         public string[] EnabledSources {  get; set; } = new [] { "System.Runtime" }; 

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector.csproj
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector.csproj
@@ -11,12 +11,13 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryType>git</RepositoryType>
     <Description>AppMetrics's extension for collect EventCounters data from EventSource's which supports it.  E.g. RuntimeEventSource or NpgsqlEventSource.</Description>
     <Copyright></Copyright>
-    <PackageReleaseNotes>0.0.4 Targeted to netstandard2.1.
+    <PackageReleaseNotes>0.0.5 Allow setting tags from event metadata
+0.0.4 Targeted to netstandard2.1.
 0.0.3 Avoid allocations
 0.0.3 Avoid allocations
 0.0.2 Fixed possible collisions on counter names from different sources

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector.csproj
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector.csproj
@@ -24,7 +24,11 @@
     <FileVersion>0.0.3.0</FileVersion>
     <TargetFrameworks>netstandard2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
-
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="App.Metrics.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/_InternalVisibleTo.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/_InternalVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnitTests")]

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/_InternalVisibleTo.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/_InternalVisibleTo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("UnitTests")]

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/UnitTests/CounterPayloadTests.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/UnitTests/CounterPayloadTests.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Neyro.AppMetrics.Extensions;
+using NUnit.Framework;
+
+namespace UnitTests
+{
+    public class CounterPayloadTests
+    {
+        public class CanExtractMetadata
+        {
+            [Test]
+            public void Test1()
+            {
+                var input = new Dictionary<string, object>()
+                {
+                    {"Name", "test-counter-event"}, {"CounterType", "Sum"}, {"Increment", 1.0},
+                    {"Metadata", "key1:value1,key2:value2"}
+                };
+                var counterPayload = new CounterPayload(input);
+                Assert.That(counterPayload.Metadata.Keys.Count, Is.EqualTo(2));
+                Assert.That(counterPayload.Metadata.Values.Count, Is.EqualTo(2));
+            }
+        }
+    }
+}

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/UnitTests/UnitTests.csproj
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/UnitTests/UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Neyro.AppMetrics.Extensions.EventCountersCollector\Neyro.AppMetrics.Extensions.EventCountersCollector.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Wanted to use some metadata in graphs but they were not available, this copies the metadata from the counters to appmetrics tags.