### PR TITLE
Fix caching of counters with metadata

### DIFF
--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollector.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollector.cs
@@ -66,7 +66,7 @@ namespace Neyro.AppMetrics.Extensions
             if (payloadFields == null)
                 return;
 
-            var payload = new CounterPayload(payloadFields);
+            var payload = new CounterPayload(payloadFields, _options.SetTagsFromMetadata);
             switch (payload.Type)
             {
                 case CounterType.Mean:
@@ -98,7 +98,7 @@ namespace Neyro.AppMetrics.Extensions
 
         private void RegisterCounterValue(CounterPayload payload, string eventSourceName)
         {
-            var countersCacheKey = eventSourceName + payload.Name;
+            var countersCacheKey = eventSourceName + payload.Key;
             if (!_counters.TryGetValue(countersCacheKey, out var counter))
             {
                 counter = new CounterOptions
@@ -118,7 +118,7 @@ namespace Neyro.AppMetrics.Extensions
 
         private void RegisterGaugeValue(CounterPayload payload, string eventSourceName)
         {
-            var gaugesCacheKey = eventSourceName + payload.Name;
+            var gaugesCacheKey = eventSourceName + payload.Key;
             if (!_gauges.TryGetValue(gaugesCacheKey, out var gauge))
             {
                 gauge = new GaugeOptions

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollector.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/EventCountersCollector.cs
@@ -106,7 +106,7 @@ namespace Neyro.AppMetrics.Extensions
                     Context = eventSourceName, Name = payload.Name, ResetOnReporting = true
                 };
 
-                if (_options.SetTagsFromMetadata)
+                if (_options.SetTagsFromMetadata && payload.Metadata != null)
                 {
                     counter.Tags = new MetricTags(payload.Metadata.Keys.ToArray(), payload.Metadata.Values.ToArray());
                 }
@@ -127,7 +127,7 @@ namespace Neyro.AppMetrics.Extensions
                     Name = payload.Name
                 };
 
-                if (_options.SetTagsFromMetadata)
+                if (_options.SetTagsFromMetadata && payload.Metadata != null)
                 {
                     gauge.Tags = new MetricTags(payload.Metadata.Keys.ToArray(), payload.Metadata.Values.ToArray());
                 }

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector.csproj
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector/Neyro.AppMetrics.Extensions.EventCountersCollector.csproj
@@ -11,12 +11,13 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
-    <Version>0.0.5</Version>
+    <Version>0.0.6</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryType>git</RepositoryType>
     <Description>AppMetrics's extension for collect EventCounters data from EventSource's which supports it.  E.g. RuntimeEventSource or NpgsqlEventSource.</Description>
     <Copyright></Copyright>
-    <PackageReleaseNotes>0.0.5 Allow setting tags from event metadata
+    <PackageReleaseNotes>0.0.6 Fix caching of counters when metadata is used
+0.0.5 Allow setting tags from event metadata
 0.0.4 Targeted to netstandard2.1.
 0.0.3 Avoid allocations
 0.0.3 Avoid allocations

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/UnitTests/CounterPayloadTests.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/UnitTests/CounterPayloadTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests
             public class AndMetadataUseIsDisabled
             {
                 [Test]
-                public void MetadataIsCopiedToCounterPayload()
+                public void MetadataIsNotCopiedToCounterPayload()
                 {
                     var input = new Dictionary<string, object>()
                     {
@@ -47,7 +47,7 @@ namespace UnitTests
                         {"Metadata", "key1:value1,key2:value2"}
                     };
                     var counterPayload = new CounterPayload(input, false);
-                    Assert.That(counterPayload.Metadata.Keys.Count, Is.EqualTo(0));
+                    Assert.IsNull(counterPayload.Metadata);
                 }
 
                 [Test]

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/UnitTests/CounterPayloadTests.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/UnitTests/CounterPayloadTests.cs
@@ -6,19 +6,61 @@ namespace UnitTests
 {
     public class CounterPayloadTests
     {
-        public class CanExtractMetadata
+        public class WhenPayloadContainsMetadata
         {
-            [Test]
-            public void Test1()
+            public class AndMetadataUseIsEnabled
             {
-                var input = new Dictionary<string, object>()
+                [Test]
+                public void MetadataIsCopiedToCounterPayload()
                 {
-                    {"Name", "test-counter-event"}, {"CounterType", "Sum"}, {"Increment", 1.0},
-                    {"Metadata", "key1:value1,key2:value2"}
-                };
-                var counterPayload = new CounterPayload(input);
-                Assert.That(counterPayload.Metadata.Keys.Count, Is.EqualTo(2));
-                Assert.That(counterPayload.Metadata.Values.Count, Is.EqualTo(2));
+                    var input = new Dictionary<string, object>()
+                    {
+                        {"Name", "test-counter-event"}, {"CounterType", "Sum"}, {"Increment", 1.0},
+                        {"Metadata", "key1:value1,key2:value2"}
+                    };
+                    var counterPayload = new CounterPayload(input, true);
+                    Assert.That(counterPayload.Metadata.Keys.Count, Is.EqualTo(2));
+                    Assert.That(counterPayload.Metadata.Values.Count, Is.EqualTo(2));
+                }
+
+                [Test]
+                public void CounteryKeyContainsMetadata()
+                {
+                    var input = new Dictionary<string, object>()
+                    {
+                        {"Name", "test-counter-event"}, {"CounterType", "Sum"}, {"Increment", 1.0},
+                        {"Metadata", "key1:value1,key2:value2"}
+                    };
+                    var counterPayload = new CounterPayload(input, true);
+                    Assert.That(counterPayload.Key, Is.EqualTo("test-counter-eventkey1:value1,key2:value2"));
+                }
+            }
+            
+            public class AndMetadataUseIsDisabled
+            {
+                [Test]
+                public void MetadataIsCopiedToCounterPayload()
+                {
+                    var input = new Dictionary<string, object>()
+                    {
+                        {"Name", "test-counter-event"}, {"CounterType", "Sum"}, {"Increment", 1.0},
+                        {"Metadata", "key1:value1,key2:value2"}
+                    };
+                    var counterPayload = new CounterPayload(input, false);
+                    Assert.That(counterPayload.Metadata.Keys.Count, Is.EqualTo(0));
+                }
+
+                [Test]
+                public void CounteryKeyDoesNotContainMetadata()
+                {
+                    var input = new Dictionary<string, object>()
+                    {
+                        {"Name", "test-counter-event"}, {"CounterType", "Sum"}, {"Increment", 1.0},
+                        {"Metadata", "key1:value1,key2:value2"}
+                    };
+                    var counterPayload = new CounterPayload(input, false);
+                    Assert.That(counterPayload.Key, Is.EqualTo("test-counter-event"));
+                }
             }
         }
     }

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/sandbox/ExampleApp/ExampleApp.csproj
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/sandbox/ExampleApp/ExampleApp.csproj
@@ -6,8 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="3.1.0" />
+    <PackageReference Include="App.Metrics.Reporting.Console" Version="3.2.0" />
     <PackageReference Include="App.Metrics.Reporting.InfluxDB" Version="3.1.0" />
-    <PackageReference Include="Neyro.AppMetrics.Extensions.EventCountersCollector" Version="0.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Neyro.AppMetrics.Extensions.EventCountersCollector\Neyro.AppMetrics.Extensions.EventCountersCollector.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/sandbox/ExampleApp/Program.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/sandbox/ExampleApp/Program.cs
@@ -14,6 +14,7 @@ namespace ExampleApp
         public static void Main(string[] args)
         {
             Metrics = AppMetrics.CreateDefaultBuilder()
+                //.Report.ToConsole()
                 .Report.ToInfluxDb(options =>
                 {
                     options.InfluxDb = new InfluxDbOptions

--- a/src/Neyro.AppMetrics.Extensions.EventCountersCollector/sandbox/ExampleApp/Program.cs
+++ b/src/Neyro.AppMetrics.Extensions.EventCountersCollector/sandbox/ExampleApp/Program.cs
@@ -37,7 +37,8 @@ namespace ExampleApp
                             new Neyro.AppMetrics.Extensions.EventCountersCollectorOptions
                             {
                                 RefreshIntervalSec = 5,
-                                EnabledSources = new[] {"System.Runtime" }
+                                EnabledSources = new[] {"System.Runtime" },
+                                SetTagsFromMetadata = true
                             }
                         )))
                         .ConfigureMetrics(Metrics)


### PR DESCRIPTION
Noticed that not all metadata was being published and looking into it turns out because when the metadata contained additional fields to ones that had already been registered before then the cache was reusing the same counter.